### PR TITLE
Update handlers.js

### DIFF
--- a/handlers.js
+++ b/handlers.js
@@ -494,7 +494,7 @@ define([
 		return function (module) {
 			module.addDependency("dojo/topic", "topic");
 			module.replaceCode(object, "topic.publish(" +
-				module.getCodeFrom(args[0]) + (args.length > 1 ? ", " + module.getCodeFrom(args[1].elements) : "") + ")");
+				module.getCodeFrom(args[0]) + (args.length > 1 ? ", " + module.getCodeFrom(args[1].type === "ArrayExpression" ? args[1].elements : args[1]) : "") + ")");
 		};
 	});
 


### PR DESCRIPTION
Make the dojo.publish support use object (not only array) as the second parameter.

Without this fix, it will throw exception like 
Unable to process file: /xxx/xxx TypeError: Cannot read property 'range' of undefined
    at Module.getCodeFrom (/Users/dev/git/dojo-amd-converter/Module.js:172:17)
    at Array.9 (/Users/dev/git/dojo-amd-converter/handlers.js:497:68)
    at /Users/dev/git/dojo-amd-converter/processScript.js:39:34
    at processPath (/Users/dev/git/dojo-amd-converter/parse.js:78:14)
    at Array.forEach (native)
    at processPath (/Users/dev/git/dojo-amd-converter/parse.js:51:32)
    at Array.forEach (native)
    at processPath (/Users/dev/git/dojo-amd-converter/parse.js:51:32)
    at Array.forEach (native)
    at processPath (/Users/dev/git/dojo-amd-converter/parse.js:51:32)
